### PR TITLE
check if the map is nil and initialize one if it's nil inside the for…

### DIFF
--- a/proxy/vless/inbound/inbound.go
+++ b/proxy/vless/inbound/inbound.go
@@ -163,6 +163,9 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 
 			fallbacks := make(map[string]map[string]*Fallback)
 			for _, fb := range h.fallbacks {
+				if fallbacks[fb.Alpn] == nil {
+					fallbacks[fb.Alpn] = make(map[string]*Fallback)
+				}
 				fallbacks[fb.Alpn][fb.Path] = fb
 			}
 


### PR DESCRIPTION
fix panic.
For nested maps when assign to the deep level key we needs to be certain that its outer key has value. Else it will say that the map is nil.